### PR TITLE
Switch to using NETCODE_DEBUG instead of NDEBUG

### DIFF
--- a/netcode.c
+++ b/netcode.c
@@ -5252,7 +5252,7 @@ static void check_handler( NETCODE_CONST char * condition,
                            int line )
 {
     printf( "check failed: ( %s ), function %s, file %s, line %d\n", condition, function, file, line );
-#ifndef NDEBUG
+#ifdef NETCODE_DEBUG
     #if defined( __GNUC__ )
         __builtin_trap();
     #elif defined( _MSC_VER )

--- a/netcode.h
+++ b/netcode.h
@@ -27,6 +27,16 @@
 
 #include <stdint.h>
 
+#if !defined(NETCODE_DEBUG) && !defined(NETCODE_RELEASE)
+#if defined(NDEBUG)
+#define NETCODE_RELEASE
+#else
+#define NETCODE_DEBUG
+#endif
+#elif defined(NETCODE_DEBUG) && defined(NETCODE_RELEASE)
+#error Can only define one of debug & release
+#endif
+
 #if    defined(__386__) || defined(i386)    || defined(__i386__)  \
     || defined(__X86)   || defined(_M_IX86)                       \
     || defined(_M_X64)  || defined(__x86_64__)                    \

--- a/premake5.lua
+++ b/premake5.lua
@@ -27,10 +27,11 @@ solution "netcode"
     configuration "Debug"
         symbols "On"
         links { debug_libs }
+        defines { "NETCODE_DEBUG" }
     configuration "Release"
         symbols "Off"
         optimize "Speed"
-        defines { "NDEBUG" }
+        defines { "NETCODE_RELEASE" }
         links { release_libs }
     configuration { "gmake" }
         linkoptions { "-lm" }    


### PR DESCRIPTION
This allows folks to control whether to use debug features on a
per-project basis. If neither is specified, NDEBUG controls the
behavior, so no changes needed for anyone who's using this library.